### PR TITLE
Cache titles, clear when air, decrease range

### DIFF
--- a/src/main/java/nl/theepicblock/baila/BailaTickHandler.java
+++ b/src/main/java/nl/theepicblock/baila/BailaTickHandler.java
@@ -1,29 +1,33 @@
 package nl.theepicblock.baila;
 
 import net.minecraft.block.BlockState;
-import net.minecraft.client.util.math.Vector3d;
 import net.minecraft.network.packet.s2c.play.TitleS2CPacket;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.hit.HitResult;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Vec3d;
-import net.minecraft.world.World;
 
 public class BailaTickHandler {
     public static void tick(ServerPlayerEntity player) {
         ServerWorld world = player.getServerWorld();
 
-        HitResult blockHit = player.rayTrace(20,0,false);
+        HitResult blockHit = player.rayTrace(8,0,false);
         BlockState blockState = world.getBlockState(((BlockHitResult)blockHit).getBlockPos());
 
-        send(player, new TranslatableText(blockState.getBlock().getTranslationKey()));
+        if (!blockState.isAir()) {
+            send(player, new TranslatableText(blockState.getBlock().getTranslationKey()));
+        } else {
+            send(player, LiteralText.EMPTY);
+        }
     }
 
     public static void send(ServerPlayerEntity player, Text text) {
-        player.networkHandler.sendPacket(new TitleS2CPacket(TitleS2CPacket.Action.ACTIONBAR,text));
+        if (!text.equals(((PlayerCachedTitle) player).getCachedActionbarTitle())) {
+            player.networkHandler.sendPacket(new TitleS2CPacket(TitleS2CPacket.Action.ACTIONBAR,text));
+            ((PlayerCachedTitle) player).setCachedActionbarTitle(text);
+        }
     }
 }

--- a/src/main/java/nl/theepicblock/baila/PlayerCachedTitle.java
+++ b/src/main/java/nl/theepicblock/baila/PlayerCachedTitle.java
@@ -1,0 +1,8 @@
+package nl.theepicblock.baila;
+
+import net.minecraft.text.Text;
+
+public interface PlayerCachedTitle {
+	Text getCachedActionbarTitle();
+	void setCachedActionbarTitle(Text cachedActionbarTitle);
+}

--- a/src/main/java/nl/theepicblock/baila/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/nl/theepicblock/baila/mixin/ServerPlayerEntityMixin.java
@@ -1,0 +1,23 @@
+package nl.theepicblock.baila.mixin;
+
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+import nl.theepicblock.baila.PlayerCachedTitle;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+@Mixin(ServerPlayerEntity.class)
+public class ServerPlayerEntityMixin implements PlayerCachedTitle {
+	@Unique
+	Text cachedActionbarTitle;
+
+	@Override
+	public Text getCachedActionbarTitle() {
+		return cachedActionbarTitle;
+	}
+
+	@Override
+	public void setCachedActionbarTitle(Text cachedActionbarTitle) {
+		this.cachedActionbarTitle = cachedActionbarTitle;
+	}
+}

--- a/src/main/resources/baila.mixins.json
+++ b/src/main/resources/baila.mixins.json
@@ -1,12 +1,13 @@
 {
-  "required": true,
-  "minVersion": "0.8",
-  "package": "nl.theepicblock.baila.mixin",
-  "compatibilityLevel": "JAVA_8",
-  "mixins": [
-    "ServerTickMixin"
-  ],
-  "injectors": {
-    "defaultRequire": 1
-  }
+	"required": true,
+	"minVersion": "0.8",
+	"package": "nl.theepicblock.baila.mixin",
+	"compatibilityLevel": "JAVA_8",
+	"mixins": [
+		"ServerPlayerEntityMixin",
+		"ServerTickMixin"
+	],
+	"injectors": {
+		"defaultRequire": 1
+	}
 }


### PR DESCRIPTION
As the title states, this PR:

- Caches actionbar titles, so they aren't sent every tick
- Clears the actionbar message when air is selected
- Decreases the range to 8, to be similar to the selection range (compat with reach-entity-attributes might be a good idea?)